### PR TITLE
🌐 i18n(en, zh): 更新英文和中文国际化翻译。

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -49,5 +49,12 @@
   "chapter_blueprint_page_placeholder": "Chapter Blueprint Page - Placeholder content",
   "character_status_page_placeholder": "Character Status Page - Placeholder content",
   "full_text_overview_page_placeholder": "Full Text Overview Page - Placeholder content",
-  "chapter_management_page_placeholder": "Chapter Management Page - Placeholder content"
+  "chapter_management_page_placeholder": "Chapter Management Page - Placeholder content",
+  "add_novel": "Add Novel",
+  "enter_novel_name": "Enter novel name",
+  "cancel": "Cancel",
+  "confirm": "Confirm",
+  "novel_already_exists": "Novel '{1}' already exists",
+  "novel_created_successfully": "Novel '{1}' created successfully",
+  "failed_to_create_novel": "Failed to create novel '{1}'"
 }

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -49,5 +49,12 @@
   "chapter_blueprint_page_placeholder": "章节蓝图页面 - 占位符内容",
   "character_status_page_placeholder": "角色状态页面 - 占位符内容",
   "full_text_overview_page_placeholder": "全文概述页面 - 占位符内容",
-  "chapter_management_page_placeholder": "章节管理页面 - 占位符内容"
+  "chapter_management_page_placeholder": "章节管理页面 - 占位符内容",
+  "add_novel": "添加小说",
+  "enter_novel_name": "请输入小说名称",
+  "cancel": "取消",
+  "confirm": "确认",
+  "novel_already_exists": "小说 '{1}' 已存在",
+  "novel_created_successfully": "小说 '{1}' 创建成功",
+  "failed_to_create_novel": "创建小说 '{1}' 失败"
 }

--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/presentation/pages/chapter_blueprint_page.dart
+++ b/lib/presentation/pages/chapter_blueprint_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../../presentation/widgets/novel_selector_dropdown.dart';
 import '../../app/localizations/app_localizations.dart';
 
 class ChapterBlueprintPage extends StatelessWidget {
@@ -15,20 +14,6 @@ class ChapterBlueprintPage extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // 添加小说选择下拉框
-            Align(
-              alignment: Alignment.topLeft,
-              child: NovelSelectorDropdown(
-                onSelected: (selectedFolder) {
-                  // 处理选择的小说文件夹
-                  if (selectedFolder != null) {
-                    // 这里可以添加处理逻辑
-                    // print('Selected novel folder: $selectedFolder');
-                  }
-                },
-              ),
-            ),
-            const SizedBox(height: 20),
             Center(
               child: Text(
                 localizations.translate('chapter_blueprint_page_placeholder'),

--- a/lib/presentation/pages/chapter_management_page.dart
+++ b/lib/presentation/pages/chapter_management_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../../presentation/widgets/novel_selector_dropdown.dart';
 import '../../app/localizations/app_localizations.dart';
 
 class ChapterManagementPage extends StatelessWidget {
@@ -15,20 +14,6 @@ class ChapterManagementPage extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // 添加小说选择下拉框
-            Align(
-              alignment: Alignment.topLeft,
-              child: NovelSelectorDropdown(
-                onSelected: (selectedFolder) {
-                  // 处理选择的小说文件夹
-                  if (selectedFolder != null) {
-                    // 这里可以添加处理逻辑
-                    // print('Selected novel folder: $selectedFolder');
-                  }
-                },
-              ),
-            ),
-            const SizedBox(height: 20),
             Center(
               child: Text(
                 localizations.translate('chapter_management_page_placeholder'),

--- a/lib/presentation/pages/character_status_page.dart
+++ b/lib/presentation/pages/character_status_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../../presentation/widgets/novel_selector_dropdown.dart';
 import '../../app/localizations/app_localizations.dart';
 
 class CharacterStatusPage extends StatelessWidget {
@@ -15,20 +14,6 @@ class CharacterStatusPage extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // 添加小说选择下拉框
-            Align(
-              alignment: Alignment.topLeft,
-              child: NovelSelectorDropdown(
-                onSelected: (selectedFolder) {
-                  // 处理选择的小说文件夹
-                  if (selectedFolder != null) {
-                    // 这里可以添加处理逻辑
-                    // print('Selected novel folder: $selectedFolder');
-                  }
-                },
-              ),
-            ),
-            const SizedBox(height: 20),
             Center(
               child: Text(
                 localizations.translate('character_status_page_placeholder'),

--- a/lib/presentation/pages/full_text_overview_page.dart
+++ b/lib/presentation/pages/full_text_overview_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../../presentation/widgets/novel_selector_dropdown.dart';
 import '../../app/localizations/app_localizations.dart';
 
 class FullTextOverviewPage extends StatelessWidget {
@@ -15,20 +14,6 @@ class FullTextOverviewPage extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // 添加小说选择下拉框
-            Align(
-              alignment: Alignment.topLeft,
-              child: NovelSelectorDropdown(
-                onSelected: (selectedFolder) {
-                  // 处理选择的小说文件夹
-                  if (selectedFolder != null) {
-                    // 这里可以添加处理逻辑
-                    // print('Selected novel folder: $selectedFolder');
-                  }
-                },
-              ),
-            ),
-            const SizedBox(height: 20),
             Center(
               child: Text(
                 localizations.translate('full_text_overview_page_placeholder'),

--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -1,6 +1,10 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import '../../presentation/widgets/navigation_drawer.dart';
+import '../../presentation/widgets/novel_selector_dropdown.dart';
 import '../../app/localizations/app_localizations.dart';
+import '../../domain/services/novel_folder_service.dart';
+import '../../domain/services/logger_service.dart';
 import 'main_features_page.dart';
 import 'novel_architecture_page.dart';
 import 'chapter_blueprint_page.dart';
@@ -18,6 +22,8 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   int _selectedIndex = 0;
+  final GlobalKey<NovelSelectorDropdownState> _novelSelectorKey =
+      GlobalKey<NovelSelectorDropdownState>();
 
   final List<Widget> _pages = [
     const MainFeaturesPage(),
@@ -46,21 +52,144 @@ class _HomePageState extends State<HomePage> {
     });
   }
 
+  /// 显示添加小说对话框
+  Future<void> _showAddNovelDialog() async {
+    final localizations = AppLocalizations.of(context);
+    String novelName = '';
+
+    return showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text(localizations.translate('add_novel')),
+          content: TextField(
+            autofocus: true,
+            decoration: InputDecoration(
+              hintText: localizations.translate('enter_novel_name'),
+            ),
+            onChanged: (value) {
+              novelName = value;
+            },
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: Text(localizations.translate('cancel')),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: Text(localizations.translate('confirm')),
+              onPressed: () async {
+                if (novelName.trim().isNotEmpty) {
+                  Navigator.of(context).pop();
+                  await _createNovelFolder(novelName.trim());
+                }
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  /// 创建小说文件夹
+  Future<void> _createNovelFolder(String novelName) async {
+    final localizations = AppLocalizations.of(context);
+    try {
+      final novelsPath = await NovelFolderService().getNovelsFolderPath();
+      final novelPath = '$novelsPath/$novelName';
+      final novelDir = Directory(novelPath);
+
+      if (await novelDir.exists()) {
+        // 如果文件夹已存在，显示错误消息
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                localizations.translateWithArgs('novel_already_exists', [
+                  novelName,
+                ]),
+              ),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+        LoggerService().logWarning(
+          'Attempted to create novel folder that already exists: $novelName',
+        );
+      } else {
+        // 创建新的小说文件夹
+        await novelDir.create(recursive: true);
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                localizations.translateWithArgs('novel_created_successfully', [
+                  novelName,
+                ]),
+              ),
+              backgroundColor: Colors.green,
+            ),
+          );
+        }
+        LoggerService().logInfo('Created new novel folder: $novelName');
+
+        // 刷新小说选择下拉框
+        _novelSelectorKey.currentState?.refreshNovelFolders();
+      }
+    } catch (e) {
+      LoggerService().logError('Failed to create novel folder: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              localizations.translateWithArgs('failed_to_create_novel', [
+                novelName,
+              ]),
+            ),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context);
-    
+
     return Scaffold(
       appBar: AppBar(
-        title: Text(localizations.translate(_pageTitles[_selectedIndex])),
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(localizations.translate(_pageTitles[_selectedIndex])),
+            const SizedBox(width: 16),
+            NovelSelectorDropdown(
+              key: _novelSelectorKey,
+              onSelected: (selectedFolder) {
+                // 处理选择的小说文件夹
+                if (selectedFolder != null) {
+                  // 这里可以添加处理逻辑
+                  // print('Selected novel folder: $selectedFolder');
+                }
+              },
+            ),
+            const SizedBox(width: 8),
+            IconButton(
+              icon: const Icon(Icons.add),
+              onPressed: _showAddNovelDialog,
+              tooltip: localizations.translate('add_novel'),
+            ),
+          ],
+        ),
       ),
       drawer: AppNavigationDrawer(
         onDestinationSelected: _onDestinationSelected,
         selectedIndex: _selectedIndex,
       ),
-      body: SingleChildScrollView(
-        child: _pages[_selectedIndex],
-      ),
+      body: SingleChildScrollView(child: _pages[_selectedIndex]),
     );
   }
 }

--- a/lib/presentation/pages/main_features_page.dart
+++ b/lib/presentation/pages/main_features_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../../presentation/widgets/novel_selector_dropdown.dart';
 import '../../app/localizations/app_localizations.dart';
 
 class MainFeaturesPage extends StatelessWidget {
@@ -8,27 +7,13 @@ class MainFeaturesPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context);
-    
+
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // 添加小说选择下拉框
-            Align(
-              alignment: Alignment.topLeft,
-              child: NovelSelectorDropdown(
-                onSelected: (selectedFolder) {
-                  // 处理选择的小说文件夹
-                  if (selectedFolder != null) {
-                    // 这里可以添加处理逻辑
-                    // print('Selected novel folder: $selectedFolder');
-                  }
-                },
-              ),
-            ),
-            const SizedBox(height: 20),
             Center(
               child: Text(
                 localizations.translate('main_features_page_placeholder'),

--- a/lib/presentation/pages/novel_architecture_page.dart
+++ b/lib/presentation/pages/novel_architecture_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../../presentation/widgets/novel_selector_dropdown.dart';
 import '../../app/localizations/app_localizations.dart';
 
 class NovelArchitecturePage extends StatelessWidget {
@@ -15,20 +14,6 @@ class NovelArchitecturePage extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // 添加小说选择下拉框
-            Align(
-              alignment: Alignment.topLeft,
-              child: NovelSelectorDropdown(
-                onSelected: (selectedFolder) {
-                  // 处理选择的小说文件夹
-                  if (selectedFolder != null) {
-                    // 这里可以添加处理逻辑
-                    // print('Selected novel folder: $selectedFolder');
-                  }
-                },
-              ),
-            ),
-            const SizedBox(height: 20),
             Center(
               child: Text(
                 localizations.translate('novel_architecture_page_placeholder'),

--- a/lib/presentation/widgets/novel_selector_dropdown.dart
+++ b/lib/presentation/widgets/novel_selector_dropdown.dart
@@ -3,21 +3,8 @@ import '../../domain/services/novel_folder_service.dart';
 import '../../domain/services/logger_service.dart';
 import '../../app/localizations/app_localizations.dart';
 
-class NovelSelectorDropdown extends StatefulWidget {
-  final Function(String?)? onSelected;
-  final String? initialValue;
-
-  const NovelSelectorDropdown({
-    super.key,
-    this.onSelected,
-    this.initialValue,
-  });
-
-  @override
-  State<NovelSelectorDropdown> createState() => _NovelSelectorDropdownState();
-}
-
-class _NovelSelectorDropdownState extends State<NovelSelectorDropdown> {
+// 将状态类改为公开的
+class NovelSelectorDropdownState extends State<NovelSelectorDropdown> {
   late Future<List<String>> _novelFoldersFuture;
   String? _selectedFolder;
 
@@ -26,6 +13,13 @@ class _NovelSelectorDropdownState extends State<NovelSelectorDropdown> {
     super.initState();
     _selectedFolder = widget.initialValue;
     _novelFoldersFuture = NovelFolderService().getNovelFolderNames();
+  }
+
+  // 刷新小说文件夹列表的方法
+  void refreshNovelFolders() {
+    setState(() {
+      _novelFoldersFuture = NovelFolderService().getNovelFolderNames();
+    });
   }
 
   @override
@@ -119,4 +113,18 @@ class _NovelSelectorDropdownState extends State<NovelSelectorDropdown> {
       },
     );
   }
+}
+
+class NovelSelectorDropdown extends StatefulWidget {
+  final Function(String?)? onSelected;
+  final String? initialValue;
+
+  const NovelSelectorDropdown({
+    super.key,
+    this.onSelected,
+    this.initialValue,
+  });
+
+  @override
+  State<NovelSelectorDropdown> createState() => NovelSelectorDropdownState();
 }


### PR DESCRIPTION
- 添加了关于添加小说相关的翻译项，包括“Add Novel”、“Enter novel name”等。

🔧 chore(lib/presentation/pages): 删除多个页面中的小说选择下拉框。

- 删除了 `chapter_blueprint_page.dart`, `chapter_management_page.dart`, `character_status_page.dart`, `full_text_overview_page.dart`, 和 `main_features_page.dart` 中的小说选择下拉框及其相关代码。

✨ feat(lib/presentation/pages/home_page): 添加添加小说功能。

- 在 `home_page.dart` 中添加了导入 `dart:io`，`novel_selector_dropdown.dart`，`app_localizations.dart`，`novel_folder_service.dart` 和 `logger_service.dart`。
- 添加了 `_HomePageState` 类中的 `_showAddNovelDialog` 方法用于显示添加小说对话框。
- 添加了 `_HomePageState` 类中的 `_createNovelFolder` 方法用于创建小说文件夹。
- 修改了 `HomePage` 的标题栏，添加了小说选择下拉框和添加小说按钮。
- 修改了 `HomePage` 的主体部分，将 `SingleChildScrollView` 的子组件改为 `_pages[_selectedIndex]`。

🛠️ refactor(lib/presentation/widgets/novel_selector_dropdown): 公开小说选择下拉框的状态类。

- 将 `NovelSelectorDropdown` 类改为公开的，并将其状态类 `NovelSelectorDropdownState` 移动到外部。

🔧 chore(lib/presentation/widgets/novel_selector_dropdown): 添加刷新小说文件夹列表的方法。

- 在 `NovelSelectorDropdownState` 类中添加了 `refreshNovelFolders` 方法用于刷新小说文件夹列表。