### PR TITLE
📝 docs(README.md): 添加LLM大模型集成文档。

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - 章节管理功能
 - 个性化设置
 - 多语言支持（中英文）
+- LLM大模型集成（支持OpenAI兼容接口）
 
 ## 界面预览
 
@@ -103,6 +104,50 @@ flutter run -d android
 2. **页面切换**：
    - 应用会根据导航栏的选择自动切换到对应页面
    - 页面标题会动态更新以反映当前所在的功能模块
+
+## LLM大模型集成
+
+本项目支持集成各种OpenAI兼容的大语言模型服务：
+
+### 配置说明
+
+在`assets/config/config.example.json`中可以找到LLM配置示例：
+
+```json
+"llm_configs": {
+    "DeepSeek V3": {
+        "api_key": "",
+        "base_url": "https://api.deepseek.com/v1",
+        "model_name": "deepseek-chat",
+        "temperature": 0.7,
+        "max_tokens": 8192,
+        "timeout": 600,
+        "interface_format": "OpenAI"
+    },
+    "GPT 5": {
+        "api_key": "",
+        "base_url": "https://api.openai.com/v1",
+        "model_name": "gpt-5",
+        "temperature": 0.7,
+        "max_tokens": 32768,
+        "timeout": 600,
+        "interface_format": "OpenAI"
+    }
+}
+```
+
+### 使用方法
+
+1. 复制`config.example.json`为`config.json`并填入你的API密钥
+2. 在应用中可以通过配置名称调用不同的LLM服务
+3. 系统支持超时重传等机制确保请求稳定性
+
+### 开发者API
+
+提供以下接口供开发者使用：
+
+- `LLMService.callLLM(prompt, configName)` - 调用指定配置的LLM
+- `LLMUseCase.generateText(prompt, configName)` - 生成文本的用例封装
 
 ## 国际化支持
 

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -102,5 +102,9 @@
   "unsaved_changes_message": "You have unsaved changes. Do you want to save them?",
   "save_successful": "Save successful",
   "save_failed": "Save failed",
-  "saving": "Saving..."
+  "saving": "Saving...",
+  "test": "Test",
+  "testing_config": "Testing configuration...",
+  "test_successful": "Test successful",
+  "test_failed": "Test failed"
 }

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -102,5 +102,9 @@
   "unsaved_changes_message": "您有未保存的更改。您想要保存更改吗？",
   "save_successful": "保存成功",
   "save_failed": "保存失败",
-  "saving": "保存中..."
+  "saving": "保存中...",
+  "test": "测试",
+  "testing_config": "正在测试配置...",
+  "test_successful": "测试成功",
+  "test_failed": "测试失败"
 }

--- a/lib/data/datasources/remote/llm_client.dart
+++ b/lib/data/datasources/remote/llm_client.dart
@@ -1,13 +1,94 @@
-import '../../models/config.dart';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:async';
+import 'package:http/http.dart' as http;
+import '../../models/llm_config.dart';
+import '../../../domain/services/logger_service.dart';
 
 class LLMClient {
-  // Implementation for LLM API adapter
-  // This is a placeholder for actual implementation
-  
-  Future<String> callLLM(String prompt, Config config) async {
-    // Call LLM API (e.g., Volcano Engine)
-    // This is a placeholder implementation
-    // In a real implementation, you would make an HTTP request to the LLM API
-    return 'Response from LLM based on prompt: $prompt';
+  static const int maxRetries = 3;
+  static const int retryDelayMs = 1000;
+
+  /// 调用LLM API
+  Future<String> callLLM(String prompt, LLMConfig config) async {
+    LoggerService().logInfo('Calling LLM: ${config.name} with model: ${config.modelName}');
+    
+    // 构建请求体
+    final requestBody = {
+      'model': config.modelName,
+      'messages': [
+        {'role': 'user', 'content': prompt}
+      ],
+      'temperature': config.temperature,
+      'max_tokens': config.maxTokens,
+    };
+
+    // 发送请求并处理重试
+    return _sendRequestWithRetry(config, requestBody);
+  }
+
+  /// 发送请求并处理重试逻辑
+  Future<String> _sendRequestWithRetry(LLMConfig config, Map<String, dynamic> requestBody) async {
+    int attempts = 0;
+    while (attempts < maxRetries) {
+      try {
+        final response = await _sendRequest(config, requestBody);
+        return response;
+      } catch (e) {
+        attempts++;
+        LoggerService().logWarning('LLM request failed (attempt $attempts): $e');
+        
+        if (attempts >= maxRetries) {
+          LoggerService().logError('LLM request failed after $maxRetries attempts: $e');
+          rethrow;
+        }
+        
+        // 等待后重试
+        await Future.delayed(Duration(milliseconds: retryDelayMs * attempts));
+      }
+    }
+    
+    throw Exception('Failed to get response from LLM after $maxRetries attempts');
+  }
+
+  /// 发送HTTP请求到LLM API
+  Future<String> _sendRequest(LLMConfig config, Map<String, dynamic> requestBody) async {
+    final url = '${config.baseUrl}/chat/completions';
+    LoggerService().logDebug('Sending request to: $url');
+    
+    final client = http.Client();
+    try {
+      final response = await client.post(
+        Uri.parse(url),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ${config.apiKey}',
+        },
+        body: jsonEncode(requestBody),
+      ).timeout(Duration(seconds: config.timeout));
+
+      LoggerService().logDebug('Response status: ${response.statusCode}');
+      
+      if (response.statusCode == 200) {
+        final jsonResponse = jsonDecode(response.body);
+        final content = jsonResponse['choices'][0]['message']['content'];
+        LoggerService().logInfo('Successfully received response from LLM');
+        return content;
+      } else {
+        LoggerService().logError('LLM API error: ${response.statusCode} - ${response.body}');
+        throw Exception('LLM API error: ${response.statusCode} - ${response.body}');
+      }
+    } on TimeoutException catch (e) {
+      LoggerService().logError('Request timeout: $e');
+      throw Exception('Request timeout: $e');
+    } on SocketException catch (e) {
+      LoggerService().logError('Network error: $e');
+      throw Exception('Network error: $e');
+    } catch (e) {
+      LoggerService().logError('Unexpected error: $e');
+      rethrow;
+    } finally {
+      client.close();
+    }
   }
 }

--- a/lib/data/models/llm_config.dart
+++ b/lib/data/models/llm_config.dart
@@ -1,0 +1,46 @@
+class LLMConfig {
+  final String name;
+  final String apiKey;
+  final String baseUrl;
+  final String modelName;
+  final double temperature;
+  final int maxTokens;
+  final int timeout;
+  final String interfaceFormat;
+
+  LLMConfig({
+    required this.name,
+    required this.apiKey,
+    required this.baseUrl,
+    required this.modelName,
+    required this.temperature,
+    required this.maxTokens,
+    required this.timeout,
+    required this.interfaceFormat,
+  });
+
+  factory LLMConfig.fromJson(String name, Map<String, dynamic> json) {
+    return LLMConfig(
+      name: name,
+      apiKey: json['api_key'] as String? ?? '',
+      baseUrl: json['base_url'] as String? ?? '',
+      modelName: json['model_name'] as String? ?? '',
+      temperature: (json['temperature'] as num? ?? 0.7).toDouble(),
+      maxTokens: json['max_tokens'] as int? ?? 2048,
+      timeout: json['timeout'] as int? ?? 300,
+      interfaceFormat: json['interface_format'] as String? ?? 'OpenAI',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'api_key': apiKey,
+      'base_url': baseUrl,
+      'model_name': modelName,
+      'temperature': temperature,
+      'max_tokens': maxTokens,
+      'timeout': timeout,
+      'interface_format': interfaceFormat,
+    };
+  }
+}

--- a/lib/domain/services/llm_service.dart
+++ b/lib/domain/services/llm_service.dart
@@ -1,0 +1,54 @@
+import '../../data/models/llm_config.dart';
+import '../../data/datasources/remote/llm_client.dart';
+import '../../utils/config_service.dart';
+import '../services/logger_service.dart';
+
+class LLMService {
+  static final LLMService _instance = LLMService._internal();
+  factory LLMService() => _instance;
+  LLMService._internal();
+
+  final LLMClient _client = LLMClient();
+
+  /// 根据配置名称获取LLM配置
+  LLMConfig? _getLLMConfig(String configName) {
+    try {
+      final config = ConfigService().getAll();
+      if (config != null && 
+          config.containsKey('llm_configs') && 
+          config['llm_configs'] is Map &&
+          (config['llm_configs'] as Map).containsKey(configName)) {
+        
+        final llmConfig = (config['llm_configs'] as Map)[configName];
+        if (llmConfig is Map<String, dynamic>) {
+          return LLMConfig.fromJson(configName, llmConfig);
+        }
+      }
+      LoggerService().logWarning('LLM config not found for: $configName');
+      return null;
+    } catch (e) {
+      LoggerService().logError('Error getting LLM config for $configName: $e');
+      return null;
+    }
+  }
+
+  /// 调用LLM并返回结果
+  Future<String> callLLM(String prompt, String configName) async {
+    LoggerService().logInfo('Calling LLM with prompt config: $configName');
+    
+    final config = _getLLMConfig(configName);
+    if (config == null) {
+      throw Exception('LLM configuration not found for: $configName');
+    }
+
+    if (config.apiKey.isEmpty) {
+      throw Exception('API key is required for LLM configuration: $configName');
+    }
+
+    if (config.baseUrl.isEmpty) {
+      throw Exception('Base URL is required for LLM configuration: $configName');
+    }
+
+    return await _client.callLLM(prompt, config);
+  }
+}

--- a/lib/domain/usecases/llm_usecase.dart
+++ b/lib/domain/usecases/llm_usecase.dart
@@ -1,0 +1,19 @@
+import '../services/llm_service.dart';
+import '../services/logger_service.dart';
+
+class LLMUseCase {
+  final LLMService _llmService = LLMService();
+
+  /// 测试LLM调用
+  Future<String> generateText(String prompt, String configName) async {
+    try {
+      LoggerService().logInfo('Generating text with LLM: $configName');
+      final result = await _llmService.callLLM(prompt, configName);
+      LoggerService().logInfo('Successfully generated text with LLM: $configName');
+      return result;
+    } catch (e) {
+      LoggerService().logError('Error generating text with LLM: $e');
+      rethrow;
+    }
+  }
+}

--- a/lib/llm_test_example.dart
+++ b/lib/llm_test_example.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+import 'package:novel_generator_flutter/domain/usecases/llm_usecase.dart';
+import 'package:novel_generator_flutter/utils/config_service.dart';
+import 'package:novel_generator_flutter/domain/services/logger_service.dart';
+
+/// 测试LLM功能的示例代码
+Future<void> testLLMFunctionality() async {
+  try {
+    // 初始化配置服务
+    await ConfigService().init();
+    await LoggerService().init();
+    
+    LoggerService().logInfo('Starting LLM test');
+    
+    // 创建LLM使用案例
+    final llmUseCase = LLMUseCase();
+    
+    // 获取配置中的第一个LLM配置名称
+    final config = ConfigService().getAll();
+    if (config != null && config.containsKey('llm_configs')) {
+      final llmConfigs = config['llm_configs'] as Map;
+      if (llmConfigs.isNotEmpty) {
+        final configName = llmConfigs.keys.first;
+        LoggerService().logInfo('Using LLM config: $configName');
+        
+        // 测试提示词
+        const prompt = "写一个关于未来世界的小故事，长度约100字。";
+        
+        // 调用LLM
+        final result = await llmUseCase.generateText(prompt, configName);
+        LoggerService().logInfo('LLM Response: $result');
+        
+        // 在控制台输出结果
+        if (LoggerService().isInitialized) {
+          LoggerService().logInfo('LLM Response: $result');
+        } else {
+          // 如果日志服务未初始化，则使用debugPrint
+          // ignore: avoid_print
+          print('LLM Response: $result');
+        }
+      } else {
+        LoggerService().logWarning('No LLM configurations found');
+        // ignore: avoid_print
+        print('No LLM configurations found');
+      }
+    } else {
+      LoggerService().logWarning('LLM configurations not found in config');
+      // ignore: avoid_print
+      print('LLM configurations not found in config');
+    }
+  } catch (e) {
+    LoggerService().logError('Error in LLM test: $e');
+    // ignore: avoid_print
+    print('Error in LLM test: $e');
+  }
+}
+
+// 程序入口点示例
+void main() async {
+  await testLLMFunctionality();
+  exit(0);
+}

--- a/lib/presentation/pages/large_model_settings_page.dart
+++ b/lib/presentation/pages/large_model_settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../app/localizations/app_localizations.dart';
 import '../../utils/config_service.dart';
+import '../../domain/usecases/llm_usecase.dart';
 
 class LargeModelSettingsPage extends StatefulWidget {
   const LargeModelSettingsPage({super.key});
@@ -299,6 +300,53 @@ class _LargeModelSettingsPageState extends State<LargeModelSettingsPage> {
     );
   }
 
+  /// 测试LLM配置
+  Future<void> _testLLMConfig(String configName) async {
+    if (!mounted) return;
+    final localizations = AppLocalizations.of(context);
+    
+    // 显示测试中提示
+    if (!mounted) return;
+    final snackBar = SnackBar(
+      content: Text(localizations.translate('testing_config')),
+      duration: const Duration(seconds: 10),
+      behavior: SnackBarBehavior.floating,
+    );
+    ScaffoldMessenger.of(context).showSnackBar(snackBar);
+    
+    try {
+      // 导入LLM使用案例
+      final llmUseCase = LLMUseCase();
+      
+      // 发送测试请求
+      await llmUseCase.generateText('test', configName);
+      
+      if (!mounted) return;
+      // 显示成功消息
+      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(localizations.translate('test_successful')),
+          backgroundColor: Colors.green,
+          duration: const Duration(seconds: 3),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      // 显示错误消息
+      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('${localizations.translate('test_failed')}: $e'),
+          backgroundColor: Colors.red,
+          duration: const Duration(seconds: 5),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+
   /// 构建配置列表项
   Widget _buildConfigListItem(
     String configType,
@@ -324,6 +372,13 @@ class _LargeModelSettingsPageState extends State<LargeModelSettingsPage> {
                 Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
+                    // 只对LLM配置显示测试按钮
+                    if (configType == 'llm_configs')
+                      IconButton(
+                        icon: const Icon(Icons.play_arrow),
+                        onPressed: () => _testLLMConfig(configName),
+                        tooltip: localizations.translate('test'),
+                      ),
                     IconButton(
                       icon: const Icon(Icons.edit),
                       onPressed: () => _showConfigDialog(


### PR DESCRIPTION
- 更新README文件，添加了对LLM大模型集成的支持说明，包括配置示例、使用方法和开发者API。

🌐 i18n(en.json, zh.json): 更新国际化文件。

- 在`en.json`和`zh.json`中添加了新的翻译项，包括“test”、“testing_config”、“test_successful”和“test_failed”。

✨ feat(llm_client.dart): 实现LLM客户端功能。

- 更新`llm_client.dart`，实现了LLM客户端的功能，包括调用LLM、发送请求并处理重试逻辑。

✨ feat(large_model_settings_page.dart): 添加LLM配置测试功能。

- 在`large_model_settings_page.dart`中添加了测试LLM配置的功能，并在UI中显示测试按钮。